### PR TITLE
depend on java-11-headless instead of java

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -17,7 +17,7 @@ Source3: log4j.properties
 Source4: zookeeper.sysconfig
 BuildRoot: %{_tmppath}/%{name}-%{rel_ver}-%{release}-root
 BuildRequires: python-devel,gcc,make,libtool,autoconf,cppunit-devel,maven,hostname,systemd,zip
-Requires: java,nc,systemd
+Requires: java-11-headless,nc,systemd
 AutoReqProv: no
 
 %description


### PR DESCRIPTION
Depend on java-11-headless instead of java as only old OpenJDK packages fulfill this dependency